### PR TITLE
Refactor(LivingEntity): Improve health property encapsulation

### DIFF
--- a/Assets/Scripts/LivingEntity.cs
+++ b/Assets/Scripts/LivingEntity.cs
@@ -7,7 +7,7 @@ public abstract class LivingEntity : MonoBehaviour
 {
     [Header("Stats")]
     [SerializeField] protected int MaxHealth = 100;
-    [SerializeField] public int Health = 100;
+    public int Health { get; private set; } = 100;
     
     public event Action HealthChanged;
 
@@ -19,7 +19,7 @@ public abstract class LivingEntity : MonoBehaviour
 
     protected virtual void Start()
     {
-        Health = MaxHealth;
+        Health = MaxHealth; 
 
         Rigidbody2D = GetComponent<Rigidbody2D>();
         Rigidbody2D.gravityScale = 0f;              // no gravity in top-down

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.multiplayer.center": "1.0.0",
     "com.unity.test-framework": "1.5.1",
     "com.unity.timeline": "1.8.7",
+    "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.10",
     "com.unity.ugui": "2.0.0",
     "com.unity.visualscripting": "1.9.6",
     "com.unity.modules.accessibility": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -173,6 +173,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "2.0.10",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.5.1",
       "depth": 0,
@@ -202,6 +218,16 @@
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.win-x86_64-linux-x86_64": {
+      "version": "2.0.10",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
The Health variable was previously a public field, which allowed any script to modify its value directly. This broke encapsulation and could lead to bugs where health values might bypass the clamping and death logic within the TakeDamage method.

This commit converts the `Health` field into a C# property with a public getter and a private setter (`{ get; private set; }`).

This change enforces that all modifications to health (both damage and healing) must go through the `TakeDamage` method. This makes the health system more robust, predictable, and less prone to bugs from direct state manipulation.