### PR TITLE
Added Player HealthSlider+ bugfix for High Health on Zombies

### DIFF
--- a/Assets/Prefabs/Bullet.prefab
+++ b/Assets/Prefabs/Bullet.prefab
@@ -49,7 +49,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 40
   lifetime: 1
-  damage: 1
+  damage: 5
 --- !u!212 &892532853481007357
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -67,6 +67,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -110,6 +113,7 @@ CapsuleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6636795345837532450}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -133,13 +137,14 @@ CapsuleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0.38000613, y: -0.000000045300254}
   m_Size: {x: 2.4918556, y: 0.70001006}
   m_Direction: 1
 --- !u!50 &4348185416447110061
 Rigidbody2D:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -150,8 +155,8 @@ Rigidbody2D:
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:

--- a/Assets/Prefabs/FlameEffect.prefab
+++ b/Assets/Prefabs/FlameEffect.prefab
@@ -27,7 +27,7 @@ Transform:
   m_GameObject: {fileID: 4058313054187432735}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.48, y: -0, z: 0}
+  m_LocalPosition: {x: 5.5, y: -0, z: 0}
   m_LocalScale: {x: 3, y: 3, z: 2}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -100,7 +100,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d28f62d7f0ad14b55a024676238a8493, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _lifetime: 0.5
+  _lifetime: 0.8
   _fadeOutDuration: 0.2
   _scaleRange: {x: 0.8, y: 1.2}
   _flickerSpeed: 10

--- a/Assets/Prefabs/Zombie Fast.prefab
+++ b/Assets/Prefabs/Zombie Fast.prefab
@@ -88,6 +88,10 @@ PrefabInstance:
       propertyPath: _knockbackForce
       value: 5
       objectReference: {fileID: 0}
+    - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
+      propertyPath: <MaxHealth>k__BackingField
+      value: 30
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/Zombie Strong.prefab
+++ b/Assets/Prefabs/Zombie Strong.prefab
@@ -78,7 +78,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
       propertyPath: _damage
-      value: 20
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
       propertyPath: MaxHealth
@@ -87,6 +87,10 @@ PrefabInstance:
     - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
       propertyPath: _knockbackForce
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
+      propertyPath: <MaxHealth>k__BackingField
+      value: 70
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Prefabs/Zombie.prefab
+++ b/Assets/Prefabs/Zombie.prefab
@@ -43,6 +43,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -178,6 +179,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -279,14 +283,16 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 94f7b59eb9f8c9940903133dc9f23668, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MaxHealth: 10
-  Health: 0
+  <MaxHealth>k__BackingField: 20
   _spriteRenderer: {fileID: 5480568683362459590}
   _damage: 10
   _knockbackForce: 6
   _audioSource: {fileID: 6132827051409800177}
   _hitFlesh: {fileID: 8300000, guid: db8d58a3af4840143ad1efae414b4171, type: 3}
   _deathSfx: {fileID: 8300000, guid: 588ccef9b33ac76468a0f8b2edb26547, type: 3}
+  _infectionSound: {fileID: 0}
+  _vaccinePickupSound: {fileID: 0}
+  _weaponPickupSound: {fileID: 0}
 --- !u!70 &3794341444429545318
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -295,6 +301,7 @@ CapsuleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2404176019906757516}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -318,7 +325,8 @@ CapsuleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0.95}
   m_Size: {x: 1.0220116, y: 2.015253}
   m_Direction: 0
@@ -330,6 +338,7 @@ CircleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2404176019906757516}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -353,13 +362,13 @@ CircleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
   m_Radius: 0.35
 --- !u!50 &7291882029051351837
 Rigidbody2D:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -370,8 +379,8 @@ Rigidbody2D:
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 2
-  m_LinearDrag: 1
-  m_AngularDrag: 1
+  m_LinearDamping: 1
+  m_AngularDamping: 1
   m_GravityScale: 0
   m_Material: {fileID: 0}
   m_IncludeLayers:

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -4938,6 +4938,95 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &207024082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 207024083}
+  - component: {fileID: 207024084}
+  m_Layer: 5
+  m_Name: HealthSlider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &207024083
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207024082}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 656103516}
+  - {fileID: 1646180403}
+  m_Father: {fileID: 1083705597}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -502, y: 445.17}
+  m_SizeDelta: {x: 256, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &207024084
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 207024082}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 419760177}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &222924787
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7672,142 +7761,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &292303137
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 292303138}
-  - component: {fileID: 292303140}
-  - component: {fileID: 292303139}
-  m_Layer: 5
-  m_Name: Health
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &292303138
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 292303137}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1083705597}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 235, y: -42}
-  m_SizeDelta: {x: 137.3573, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &292303139
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 292303137}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 100
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294964736
-  m_fontColor: {r: 0, g: 0.9660373, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &292303140
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 292303137}
-  m_CullTransparentMesh: 1
 --- !u!1 &294787794
 GameObject:
   m_ObjectHideFlags: 0
@@ -8994,7 +8947,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ab26963c09022b54193bbbbf24803ff4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _health: {fileID: 292303139}
+  _healthSlider: {fileID: 207024084}
   _timeLeft: {fileID: 272394288}
   _gameOverPanel: {fileID: 620519963}
   _gameOverText: {fileID: 344178363}
@@ -11422,6 +11375,81 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &419760176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 419760177}
+  - component: {fileID: 419760179}
+  - component: {fileID: 419760178}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &419760177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 419760176}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1646180403}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &419760178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 419760176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8207547, g: 0.127759, b: 0.127759, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &419760179
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 419760176}
+  m_CullTransparentMesh: 1
 --- !u!1 &431510670
 GameObject:
   m_ObjectHideFlags: 0
@@ -13528,142 +13556,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &474830440
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 474830441}
-  - component: {fileID: 474830443}
-  - component: {fileID: 474830442}
-  m_Layer: 5
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &474830441
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 474830440}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1083705597}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 90.67865, y: -42}
-  m_SizeDelta: {x: 137.3573, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &474830442
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 474830440}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 'Health:'
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294964736
-  m_fontColor: {r: 0, g: 0.9660373, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 1
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &474830443
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 474830440}
-  m_CullTransparentMesh: 1
 --- !u!1001 &478459603
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18439,6 +18331,81 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &656103515
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 656103516}
+  - component: {fileID: 656103518}
+  - component: {fileID: 656103517}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &656103516
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656103515}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 207024083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &656103517
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656103515}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &656103518
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 656103515}
+  m_CullTransparentMesh: 1
 --- !u!1 &657349595
 GameObject:
   m_ObjectHideFlags: 0
@@ -21111,7 +21078,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9aadb216542f713418f4b471fef6285e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MaxHealth: 100
   _spriteRenderer: {fileID: 155509589}
   _audioSource: {fileID: 1483325642}
   _infectionSound: {fileID: 0}
@@ -30816,13 +30782,12 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 474830441}
-  - {fileID: 292303138}
   - {fileID: 1736684364}
   - {fileID: 272394287}
   - {fileID: 620519963}
   - {fileID: 1082408128}
   - {fileID: 81136042}
+  - {fileID: 207024083}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -46180,6 +46145,42 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1646180402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1646180403}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1646180403
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1646180402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 419760177}
+  m_Father: {fileID: 207024083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1647105856
 GameObject:
   m_ObjectHideFlags: 0
@@ -57657,7 +57658,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   version: 1
   data:
-    dataString: UEsDBBQAAAgIAMA7IezqMISZggIAAD0FAAALACQAZ3JhcGgwLmpzb24KACAAAAAAAAEAGAAAgD7V3rGdAQCAPtXesZ0BAIA+1d6xnQF1VMFy4jAM/RXG54VJCCHt3naB0j20Zcru9JKLiRXiwbEztlOgHf59ZSchKTt7QjxJT9KTnE/Cpakgs0qvNWdPigH5PiLOJt9GvfMRTnSv5JZ/QBfzxpktXBD1Ma/UcoV46NKMKsFqnv2Qe+GCAwRryXOlyxXbw0IZaxDOqTCALq2sy5YIfY7ICX/G9y7ljNY0cdYHWvfB6IJmBtKCHoQGkygOgjBKoqjNGYeTBKHpdB63ueNoEk7vo3mSJKtxkHiiWmaClhUwN1XPF8bJJG6Jwng2aYIlTt3GBZPEtaGE4KZtmthz5UXZVgVocKowTlED36iTpAC+L6ybZ5j7kucGbCuQpucl1yhlQ0p+qkbfkppD0947FbUrk0x9Tw3n0z/ucejduVblY1c2DFwJW/Ds8ErPGTV2oP8QXn7tu5ZHKg50J+CtAPms1lrVkqHT6tql1gamy/7vdbJFAdmhx5tWO7CrW1e97N2+u227IS5++tNC8HLnhZ81wFYoL7c/EtC4ml/YsT8h01Ig6tr4Y+A33Q9vrXU8cG0sutoxpetvp2rtQsnKi+bGqe1CaQl6yFCBpMKeN8hjb3d44/t/1gN1z6qt3vq613KT4uE+PghuXBt1vK7LFOr4BKZ4qa3gEvoFOMczCrVQUjYnNhypS9vWOqfZIG1fc/b1uEg83yVzejfPaJBF+W42vkvYLI+i2d2OxcAgIP76uMQ5qdg0jbby4NpkTy7x0rqvzWitaeXPnWl6XPOPUpk+kstcbTMNIF8ahmvjoLEIvku2YhwF2oK1XPqFk8+UCJUdgKVXotRPujpZTdOeJSUVf1fWISlZ+M9LShx8veaNhncOR1e8I7uQy19QSwMEFAAACAgAwDsh7L30Ey1tAAAAeAAAAAkAJABtZXRhLmpzb24KACAAAAAAAAEAGAAAgD7V3rGdAQCAPtXesZ0BAIA+1d6xnQGrVipLLSrOzM9TslIw0TPSMzTXUVBKL0osyCgGihiCOKWZKSB2tJKpWZK5WaKFWXKiQbJxWpKJroV5ikmasbGJRVKKaWpKqoFSLFB9SWVBql9ibipET0BiSUZaZl5KZl66nntRZoo7yGil2FoAUEsBAi0AFAAACAgAwDsh7OowhJmCAgAAPQUAAAsAJAAAAAAAAAAAAAAAAAAAAGdyYXBoMC5qc29uCgAgAAAAAAABABgAAIA+1d6xnQEAgD7V3rGdAQCAPtXesZ0BUEsBAi0AFAAACAgAwDsh7L30Ey1tAAAAeAAAAAkAJAAAAAAAAAAAAAAAzwIAAG1ldGEuanNvbgoAIAAAAAAAAQAYAACAPtXesZ0BAIA+1d6xnQEAgD7V3rGdAVBLBQYAAAAAAgACALgAAACHAwAAAAA=
+    dataString: UEsDBBQAAAgIAABAIezqMISZggIAAD0FAAALACQAZ3JhcGgwLmpzb24KACAAAAAAAAEAGAAAgD7V3rGdAQCAPtXesZ0BAIA+1d6xnQF1VMFy4jAM/RXG54VJCCHt3naB0j20Zcru9JKLiRXiwbEztlOgHf59ZSchKTt7QjxJT9KTnE/Cpakgs0qvNWdPigH5PiLOJt9GvfMRTnSv5JZ/QBfzxpktXBD1Ma/UcoV46NKMKsFqnv2Qe+GCAwRryXOlyxXbw0IZaxDOqTCALq2sy5YIfY7ICX/G9y7ljNY0cdYHWvfB6IJmBtKCHoQGkygOgjBKoqjNGYeTBKHpdB63ueNoEk7vo3mSJKtxkHiiWmaClhUwN1XPF8bJJG6Jwng2aYIlTt3GBZPEtaGE4KZtmthz5UXZVgVocKowTlED36iTpAC+L6ybZ5j7kucGbCuQpucl1yhlQ0p+qkbfkppD0947FbUrk0x9Tw3n0z/ucejduVblY1c2DFwJW/Ds8ErPGTV2oP8QXn7tu5ZHKg50J+CtAPms1lrVkqHT6tql1gamy/7vdbJFAdmhx5tWO7CrW1e97N2+u227IS5++tNC8HLnhZ81wFYoL7c/EtC4ml/YsT8h01Ig6tr4Y+A33Q9vrXU8cG0sutoxpetvp2rtQsnKi+bGqe1CaQl6yFCBpMKeN8hjb3d44/t/1gN1z6qt3vq613KT4uE+PghuXBt1vK7LFOr4BKZ4qa3gEvoFOMczCrVQUjYnNhypS9vWOqfZIG1fc/b1uEg83yVzejfPaJBF+W42vkvYLI+i2d2OxcAgIP76uMQ5qdg0jbby4NpkTy7x0rqvzWitaeXPnWl6XPOPUpk+kstcbTMNIF8ahmvjoLEIvku2YhwF2oK1XPqFk8+UCJUdgKVXotRPujpZTdOeJSUVf1fWISlZ+M9LShx8veaNhncOR1e8I7uQy19QSwMEFAAACAgAAEAh7L30Ey1tAAAAeAAAAAkAJABtZXRhLmpzb24KACAAAAAAAAEAGAAAgD7V3rGdAQCAPtXesZ0BAIA+1d6xnQGrVipLLSrOzM9TslIw0TPSMzTXUVBKL0osyCgGihiCOKWZKSB2tJKpWZK5WaKFWXKiQbJxWpKJroV5ikmasbGJRVKKaWpKqoFSLFB9SWVBql9ibipET0BiSUZaZl5KZl66nntRZoo7yGil2FoAUEsBAi0AFAAACAgAAEAh7OowhJmCAgAAPQUAAAsAJAAAAAAAAAAAAAAAAAAAAGdyYXBoMC5qc29uCgAgAAAAAAABABgAAIA+1d6xnQEAgD7V3rGdAQCAPtXesZ0BUEsBAi0AFAAACAgAAEAh7L30Ey1tAAAAeAAAAAkAJAAAAAAAAAAAAAAAzwIAAG1ldGEuanNvbgoAIAAAAAAAAQAYAACAPtXesZ0BAIA+1d6xnQEAgD7V3rGdAVBLBQYAAAAAAgACALgAAACHAwAAAAA=
     upgradeData: 
     file_cachedStartup: {fileID: 0}
     data_cachedStartup: 

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -21078,6 +21078,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9aadb216542f713418f4b471fef6285e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  <MaxHealth>k__BackingField: 100
   _spriteRenderer: {fileID: 155509589}
   _audioSource: {fileID: 1483325642}
   _infectionSound: {fileID: 0}
@@ -58457,6 +58458,10 @@ PrefabInstance:
     - target: {fileID: 5050959255939929263, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7645245558220071672, guid: 58a81432dd3abc34daba2cff26d47403, type: 3}
+      propertyPath: <MaxHealth>k__BackingField
+      value: 40
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scripts/LivingEntity.cs
+++ b/Assets/Scripts/LivingEntity.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 public abstract class LivingEntity : MonoBehaviour
 {
     [Header("Stats")]
-    [SerializeField] protected int MaxHealth = 100;
+    public int MaxHealth { get; private set; } = 100; // Changed from protected to public
     public int Health { get; private set; } = 100;
     
     public event Action HealthChanged;

--- a/Assets/Scripts/LivingEntity.cs
+++ b/Assets/Scripts/LivingEntity.cs
@@ -1,3 +1,49 @@
+// using System;
+// using UnityEngine;
+
+// [RequireComponent(typeof(Collider2D))]
+// [RequireComponent(typeof(Rigidbody2D))]
+// public abstract class LivingEntity : MonoBehaviour
+// {
+//     [Header("Stats")]
+//     public int MaxHealth { get; private set; } = 100; // Changed from protected to public
+//     public int Health { get; private set; } = 100;
+    
+//     public event Action HealthChanged;
+
+//     // [Header("Colliders")]
+//     // [SerializeField] protected Collider2D HitboxCollider;   // trigger for damage
+//     // [SerializeField] protected Collider2D GroundCollider;   // solid body collider
+
+//     protected Rigidbody2D Rigidbody2D;
+
+//     protected virtual void Start()
+//     {
+//         Health = MaxHealth; 
+
+//         Rigidbody2D = GetComponent<Rigidbody2D>();
+//         Rigidbody2D.gravityScale = 0f;              // no gravity in top-down
+//         Rigidbody2D.constraints = RigidbodyConstraints2D.FreezeRotation;
+
+//         // if (HitboxCollider != null) HitboxCollider.isTrigger = true;
+//         // if (GroundCollider != null) GroundCollider.isTrigger = false;
+//     }
+
+//     public virtual void TakeDamage(int damage)
+//     {
+//         Health = Mathf.Clamp(Health - damage, 0, MaxHealth);
+//         HealthChanged?.Invoke();
+//         if (Health <= 0)
+//             Die();
+//     }
+
+//     protected virtual void Die()
+//     {
+//         Debug.Log($"{name} died");
+//         Destroy(gameObject);
+//     }
+// }
+
 using System;
 using UnityEngine;
 
@@ -6,14 +52,12 @@ using UnityEngine;
 public abstract class LivingEntity : MonoBehaviour
 {
     [Header("Stats")]
-    public int MaxHealth { get; private set; } = 100; // Changed from protected to public
+    // MODIFIED: Added [field: SerializeField]
+    // This attribute tells Unity to show this property in the Inspector.
+    [field: SerializeField] public int MaxHealth { get; protected set; } = 100;
     public int Health { get; private set; } = 100;
     
     public event Action HealthChanged;
-
-    // [Header("Colliders")]
-    // [SerializeField] protected Collider2D HitboxCollider;   // trigger for damage
-    // [SerializeField] protected Collider2D GroundCollider;   // solid body collider
 
     protected Rigidbody2D Rigidbody2D;
 
@@ -22,11 +66,8 @@ public abstract class LivingEntity : MonoBehaviour
         Health = MaxHealth; 
 
         Rigidbody2D = GetComponent<Rigidbody2D>();
-        Rigidbody2D.gravityScale = 0f;              // no gravity in top-down
+        Rigidbody2D.gravityScale = 0f;
         Rigidbody2D.constraints = RigidbodyConstraints2D.FreezeRotation;
-
-        // if (HitboxCollider != null) HitboxCollider.isTrigger = true;
-        // if (GroundCollider != null) GroundCollider.isTrigger = false;
     }
 
     public virtual void TakeDamage(int damage)
@@ -43,3 +84,4 @@ public abstract class LivingEntity : MonoBehaviour
         Destroy(gameObject);
     }
 }
+

--- a/Assets/Scripts/LivingEntity.cs
+++ b/Assets/Scripts/LivingEntity.cs
@@ -1,5 +1,3 @@
-// using System;
-// using UnityEngine;
 
 // [RequireComponent(typeof(Collider2D))]
 // [RequireComponent(typeof(Rigidbody2D))]

--- a/Assets/Scripts/LivingEntity.cs
+++ b/Assets/Scripts/LivingEntity.cs
@@ -1,46 +1,4 @@
 
-// [RequireComponent(typeof(Collider2D))]
-// [RequireComponent(typeof(Rigidbody2D))]
-// public abstract class LivingEntity : MonoBehaviour
-// {
-//     [Header("Stats")]
-//     public int MaxHealth { get; private set; } = 100; // Changed from protected to public
-//     public int Health { get; private set; } = 100;
-    
-//     public event Action HealthChanged;
-
-//     // [Header("Colliders")]
-//     // [SerializeField] protected Collider2D HitboxCollider;   // trigger for damage
-//     // [SerializeField] protected Collider2D GroundCollider;   // solid body collider
-
-//     protected Rigidbody2D Rigidbody2D;
-
-//     protected virtual void Start()
-//     {
-//         Health = MaxHealth; 
-
-//         Rigidbody2D = GetComponent<Rigidbody2D>();
-//         Rigidbody2D.gravityScale = 0f;              // no gravity in top-down
-//         Rigidbody2D.constraints = RigidbodyConstraints2D.FreezeRotation;
-
-//         // if (HitboxCollider != null) HitboxCollider.isTrigger = true;
-//         // if (GroundCollider != null) GroundCollider.isTrigger = false;
-//     }
-
-//     public virtual void TakeDamage(int damage)
-//     {
-//         Health = Mathf.Clamp(Health - damage, 0, MaxHealth);
-//         HealthChanged?.Invoke();
-//         if (Health <= 0)
-//             Die();
-//     }
-
-//     protected virtual void Die()
-//     {
-//         Debug.Log($"{name} died");
-//         Destroy(gameObject);
-//     }
-// }
 
 using System;
 using UnityEngine;

--- a/Assets/Scripts/UIController.cs
+++ b/Assets/Scripts/UIController.cs
@@ -1,42 +1,106 @@
+// using TMPro;
+// using UnityEngine;
+// using UnityEngine.SceneManagement;
+// using UnityEngine.UI;
+
+// public class UIController : MonoBehaviour
+// {
+//     [SerializeField] private TextMeshProUGUI _health;
+//     [SerializeField] private TextMeshProUGUI _timeLeft;
+//     [SerializeField] private RectTransform _gameOverPanel;
+//     [SerializeField] private TextMeshProUGUI _gameOverText;
+//     [SerializeField] private Button _titleScreenButton;
+//     [SerializeField] private GameController _gameController;
+//     [SerializeField] private Player _player;
+//     [SerializeField] private GameTimer _timer;
+
+//     private void Start()
+//     {
+//         _gameOverPanel.gameObject.SetActive(false);
+        
+//         _player.HealthChanged += SetHealthText;
+//         _timer.TimeLeftChanged += SetTimerText;
+//         _gameController.GameOverTriggered += OnGameOverTriggered;
+//         _titleScreenButton.onClick.AddListener(OnTitleScreenButtonClicked);
+        
+//         SetTimerText(_timer.TimeLeft);
+//     }
+
+//     private void OnDestroy()
+//     {
+//         _player.HealthChanged -= SetHealthText;
+//         _timer.TimeLeftChanged -= SetTimerText;
+//         _gameController.GameOverTriggered -= OnGameOverTriggered;
+//         _titleScreenButton.onClick.RemoveAllListeners();
+//     }
+    
+//     private void OnTitleScreenButtonClicked() => SceneManager.LoadScene(0);
+//     private void SetHealthText() => _health.text = _player.Health.ToString();
+//     private void SetTimerText(int timeLeft) => _timeLeft.text = $"{timeLeft / 60:D2}:{timeLeft % 60:D2}";
+//     private void OnGameOverTriggered(bool win)
+//     {
+//         _gameOverPanel.gameObject.SetActive(true);
+//         _gameOverText.text = win ? "YOU WIN!" : "GAME OVER";
+//     }
+// }
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
+using UnityEngine.UI; // IMPORTANT: Make sure you have this line for the Slider
 
 public class UIController : MonoBehaviour
 {
-    [SerializeField] private TextMeshProUGUI _health;
+    // MODIFIED: Changed the _health variable from TextMeshProUGUI to Slider
+    [SerializeField] private Slider _healthSlider; 
     [SerializeField] private TextMeshProUGUI _timeLeft;
     [SerializeField] private RectTransform _gameOverPanel;
     [SerializeField] private TextMeshProUGUI _gameOverText;
     [SerializeField] private Button _titleScreenButton;
     [SerializeField] private GameController _gameController;
-    [SerializeField] private Player _player;
+    [SerializeField] private Player _player; // I'm assuming your Player class inherits from LivingEntity
     [SerializeField] private GameTimer _timer;
 
     private void Start()
     {
         _gameOverPanel.gameObject.SetActive(false);
         
-        _player.HealthChanged += SetHealthText;
+        // MODIFIED: Subscribe the new UpdateHealthBar method to the event
+        _player.HealthChanged += UpdateHealthBar; 
         _timer.TimeLeftChanged += SetTimerText;
         _gameController.GameOverTriggered += OnGameOverTriggered;
         _titleScreenButton.onClick.AddListener(OnTitleScreenButtonClicked);
         
         SetTimerText(_timer.TimeLeft);
+
+        // ADDED: Set the health bar to the correct starting value when the game begins.
+        UpdateHealthBar();
     }
 
     private void OnDestroy()
     {
-        _player.HealthChanged -= SetHealthText;
+        // MODIFIED: Unsubscribe the new method
+        _player.HealthChanged -= UpdateHealthBar;
         _timer.TimeLeftChanged -= SetTimerText;
         _gameController.GameOverTriggered -= OnGameOverTriggered;
         _titleScreenButton.onClick.RemoveAllListeners();
     }
     
     private void OnTitleScreenButtonClicked() => SceneManager.LoadScene(0);
-    private void SetHealthText() => _health.text = _player.Health.ToString();
+
+    // DELETED: The old SetHealthText method is no longer needed.
+    // private void SetHealthText() => _health.text = _player.Health.ToString();
+
+    // NEW METHOD: This calculates and sets the slider's value.
+    private void UpdateHealthBar()
+    {
+        // Your LivingEntity script already has Health and MaxHealth, which is perfect!
+        // We calculate the health percentage and set the slider's value.
+        // We cast to float to prevent integer division (which would result in 0 or 1).
+        _healthSlider.value = (float)_player.Health / _player.MaxHealth;
+    }
+    
     private void SetTimerText(int timeLeft) => _timeLeft.text = $"{timeLeft / 60:D2}:{timeLeft % 60:D2}";
+    
     private void OnGameOverTriggered(bool win)
     {
         _gameOverPanel.gameObject.SetActive(true);

--- a/Assets/Scripts/Zombie.cs
+++ b/Assets/Scripts/Zombie.cs
@@ -25,7 +25,7 @@ public class Zombie : LivingEntity
     {
         base.Start();
         _aiPath = GetComponent<AIPath>();
-        _tutorialManager = FindObjectOfType<TutorialManager>();
+        _tutorialManager = FindAnyObjectByType<TutorialManager>();
 
         var playerObj = GameObject.FindGameObjectWithTag("Player");
         if (playerObj != null)

--- a/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Button.png.meta
+++ b/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Button.png.meta
@@ -1,5 +1,12 @@
 fileFormatVersion: 2
 guid: 7c5eeca09e4f8e94b8545f7fac9584da
+AssetOrigin:
+  serializedVersion: 1
+  productId: 310347
+  packageName: Zombie City - HD Isometric Tileset
+  packageVersion: 1.1
+  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Button.png
+  uploadId: 738682
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -67,7 +74,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 0
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 32
     resizeAlgorithm: 0
@@ -80,7 +87,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -93,7 +100,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -106,10 +113,50 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
@@ -119,16 +166,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 310347
-  packageName: Zombie City - HD Isometric Tileset
-  packageVersion: 1.1
-  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Button.png
-  uploadId: 738682

--- a/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonMask.png.meta
+++ b/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonMask.png.meta
@@ -1,5 +1,12 @@
 fileFormatVersion: 2
 guid: 8a03980d4ce61bc42afe3607c377f9f3
+AssetOrigin:
+  serializedVersion: 1
+  productId: 310347
+  packageName: Zombie City - HD Isometric Tileset
+  packageVersion: 1.1
+  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonMask.png
+  uploadId: 738682
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -67,7 +74,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 0
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -80,7 +87,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -93,8 +100,47 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
@@ -110,6 +156,7 @@ TextureImporter:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
@@ -119,16 +166,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 310347
-  packageName: Zombie City - HD Isometric Tileset
-  packageVersion: 1.1
-  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonMask.png
-  uploadId: 738682

--- a/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonRing.png.meta
+++ b/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonRing.png.meta
@@ -1,5 +1,12 @@
 fileFormatVersion: 2
 guid: 6b9a76b2186477e4dae57106a5213620
+AssetOrigin:
+  serializedVersion: 1
+  productId: 310347
+  packageName: Zombie City - HD Isometric Tileset
+  packageVersion: 1.1
+  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonRing.png
+  uploadId: 738682
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -67,7 +74,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 0
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 32
     resizeAlgorithm: 0
@@ -80,7 +87,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -93,7 +100,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -106,10 +113,50 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
+    maxTextureSize: 32
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
@@ -119,16 +166,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 310347
-  packageName: Zombie City - HD Isometric Tileset
-  packageVersion: 1.1
-  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/ButtonRing.png
-  uploadId: 738682

--- a/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Gradient.png.meta
+++ b/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Gradient.png.meta
@@ -1,5 +1,12 @@
 fileFormatVersion: 2
 guid: 4c45d80b67cd96a468308733afef4e60
+AssetOrigin:
+  serializedVersion: 1
+  productId: 310347
+  packageName: Zombie City - HD Isometric Tileset
+  packageVersion: 1.1
+  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Gradient.png
+  uploadId: 738682
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -67,7 +74,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 0
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -80,7 +87,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -93,8 +100,47 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
     maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
@@ -110,6 +156,7 @@ TextureImporter:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
@@ -119,16 +166,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 310347
-  packageName: Zombie City - HD Isometric Tileset
-  packageVersion: 1.1
-  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Gradient.png
-  uploadId: 738682

--- a/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Portraits/PlayerPortrait.png.meta
+++ b/Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Portraits/PlayerPortrait.png.meta
@@ -1,5 +1,12 @@
 fileFormatVersion: 2
 guid: 323f3affd458a5a419ca402902f9a4ea
+AssetOrigin:
+  serializedVersion: 1
+  productId: 310347
+  packageName: Zombie City - HD Isometric Tileset
+  packageVersion: 1.1
+  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Portraits/PlayerPortrait.png
+  uploadId: 738682
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -67,7 +74,7 @@ TextureImporter:
   swizzle: 50462976
   cookieLightType: 0
   platformSettings:
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: DefaultTexturePlatform
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -80,7 +87,7 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
-  - serializedVersion: 3
+  - serializedVersion: 4
     buildTarget: Standalone
     maxTextureSize: 2048
     resizeAlgorithm: 0
@@ -93,10 +100,50 @@ TextureImporter:
     ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 4
+    buildTarget: WindowsStoreApps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
+    customData: 
     physicsShape: []
     bones: []
     spriteID: 5e97eb03825dee720800000000000000
@@ -106,16 +153,11 @@ TextureImporter:
     edges: []
     weights: []
     secondaryTextures: []
+    spriteCustomMetadata:
+      entries: []
     nameFileIdTable: {}
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 
-AssetOrigin:
-  serializedVersion: 1
-  productId: 310347
-  packageName: Zombie City - HD Isometric Tileset
-  packageVersion: 1.1
-  assetPath: Assets/SmallScaleInt/2D Zombie City Tile pack 1/Example Scene/UI/Portraits/PlayerPortrait.png
-  uploadId: 738682


### PR DESCRIPTION
Added Player HealthSlider to replace Health Text.  Added SerializeField to MaxHealth to fix High Health Value by default on all Zombies. 

Damage rescale for Bullets.
Health Rescale for all Zombies. 